### PR TITLE
Minor fixes

### DIFF
--- a/langs/en.properties
+++ b/langs/en.properties
@@ -1,5 +1,5 @@
 ﻿; Notes
-; You can use <b class='note'>Note:</b> ... to bring attention to a note.  
+; You can use <b class='note'>Note:</b> ... to bring attention to a note.
 ; Be aware that, if you start a string with something in markup, you'll need to add <p> markup too.  So, a note string might start "<p><b class='note'>Note...".
 
 
@@ -36,8 +36,8 @@ label_mimetype="Served as:"
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 footer_about="About"
 footer_about_title="Information About this Service"
-footer_download="Github"
-footer_download_title="Download the sources for this service"
+footer_download="GitHub"
+footer_download_title="Source code and instructions to build and test"
 footer_feedback="Feedback"
 footer_feedback_title="How to provide feedback on this service"
 footer_home="Home"

--- a/www/about.php
+++ b/www/about.php
@@ -42,7 +42,8 @@ $hideLangSelection = true;
 	<p>The reports take into account both markup and HTTP headers, which can be particularly useful for
     troubleshooting problems. The advice given in the checker  reports considers how your HMTL pages (ie. files served as <code class="kw" translate="no">text/html</code>)  will behave in a modern browser, rather than just validating against a particular version of the standard. The advice is tailored to suit files served as <code class="kw" translate="no">application/xhtml+xml</code> for aspects relating to character encoding and language declaration.</p>
 	<p>Please let us know about bugs and missing features using the <a href="https://github.com/w3c/i18n-checker/issues">feedback form</a>.</p>
-	<p>This software is free / open source, licensed under the terms of <a href="https://github.com/w3c/i18n-checker/blob/master/LICENSE.html">[LICENCE]</a>. The source code is available on <a href="https://github.com/w3c/i18n-checker">Github</a>.</p>
+	<p>This software is licensed under the terms of the <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">W3C Software and Document Notice and License</a>.
+    The source code is available <a href="https://github.com/w3c/i18n-checker">on GitHub</a>.</p>
 </div>
 
 <h3 id="others">References and other resources</h3>


### PR DESCRIPTION
* Fix placeholder `[LICENCE]` and point to a readable version of the license (not the raw HTML).
* GitHub better spelt in CamelCase.