### PR TITLE
Default colours for body

### DIFF
--- a/www/style/base_ucn.css
+++ b/www/style/base_ucn.css
@@ -50,6 +50,8 @@ legend {
 body {
 	min-width: 40em;
 	padding-bottom: 2em;
+	color:#000;
+	background-color:#fff;
 }
 
 #frontforms,#don_program,#menu,#footer,#translations,#summary,#source,#results


### PR DESCRIPTION
Necessary for accessibility needs: when one provides background for some elements, one must always provide foreground colour, and vice-versa. (for instance in current CSS, THs have background but no colour).
Simple fix: set black text on white background in the CSS, it's coherent with the rest of the W3C pages.